### PR TITLE
the `scipy.ndimage.morphology` namespace is deprecated.

### DIFF
--- a/jointforces/growth.py
+++ b/jointforces/growth.py
@@ -4,7 +4,7 @@ import pandas as pd
 from glob import glob
 from tqdm import tqdm
 from natsort import natsorted
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 from .utils import load
 import os
 import matplotlib


### PR DESCRIPTION
With `scipy 1.8.0` some namespaces became deprectated:

jointforces/growth.py:7: DeprecationWarning: Please use `distance_transform_edt` from the `scipy.ndimage` namespace, the `scipy.ndimage.morphology` namespace is deprecated.