### PR TITLE
Do not fix the saenopy version too strict

### DIFF
--- a/jointforces/growth.py
+++ b/jointforces/growth.py
@@ -4,7 +4,7 @@ import pandas as pd
 from glob import glob
 from tqdm import tqdm
 from natsort import natsorted
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 from .utils import load
 import os
 import matplotlib

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author='Christoph Mark, David Böhringer',
     author_email='christoph.mark@fau.de',
     license='The MIT License (MIT)',
-    install_requires=['saenopy==0.7.4', 
+    install_requires=['saenopy>=0.7.4',
                       'gmsh-sdk>=4.5.0',
                       'numpy>=1.16.2',
                       'pandas>=1.1.5',


### PR DESCRIPTION
I cannot relase a new version of saenopy as saenopy depends on jointforces and jointforces requires exactly saenopy 0.7.4 so when I change the version number of saenopy it cannot resolve its jointforces dependency anymore.